### PR TITLE
Implement argument for starting multiple workers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,24 +10,37 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  tests:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - uses: gabrielfalcao/pyenv-action@v18
-      with:
-        default: 3.12
-
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - uses: giraffate/clippy-action@v1
-      with:
-        reporter: 'github-pr-review'
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        level: warning
-        clippy_flags: -- -Dwarnings
+      - uses: actions/checkout@v4
+      - uses: gabrielfalcao/pyenv-action@v18
+        with:
+          default: 3.12
+      - name: Build
+        shell: bash
+        run: cargo build --verbose
+      - name: Run tests
+        shell: bash
+        run: cargo test --verbose
+  clippy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write  
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gabrielfalcao/pyenv-action@v18
+        with:
+          default: 3.12
+      - name: Build
+        shell: bash
+        run: cargo build --verbose
+      - name: Install reviewdog
+        uses: reviewdog/action-setup@v1
+      - name: Run clippy with reviewdog
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cargo clippy --message-format=json | reviewdog -f=clippy -reporter=github-pr-check
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - uses: gabrielfalcao/pyenv-action@v18
+      with:
+        default: 3.12
+
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "asgi"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "bincode",
  "http-body-util",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "messages"
-version = "0.1.0"
+version = "0.0.2"
 dependencies = [
  "hyper",
  "serde",
@@ -633,16 +633,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
 ]
 
 [[package]]
@@ -892,7 +882,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "worker"
-version = "0.1.0"
+version = "0.0.2"
 dependencies = [
  "bincode",
  "clap",
@@ -902,6 +892,5 @@ dependencies = [
  "pyo3",
  "pyo3-build-config",
  "serde",
- "signal-hook",
  "tokio",
 ]


### PR DESCRIPTION
This PR adds an argument to allow start multiple workers to allow leveraging multiple CPU, requests are distributed with round-robin algorithm. Default for now is 1.

Bonus: improvement in the PR checks
